### PR TITLE
Link bracketed numbers to sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ List of Linux Tools I put on almost every Linux / Debian host
 - [**wireshark**](https://www.wireshark.org) -> network packet reviewer
 - [**Visual Studio Code**](https://code.visualstudio.com) -> (```sudo snap install --classic code```)
 - [**guake**](https://github.com/Guake/guake) -> GUI terminal client for linux, more options than the built in terminal
-- [**tabby**](https://tabby.sh) -> Modern, feature-rich terminal emulator with excellent cross-platform support[8]
+- [**tabby**](https://tabby.sh) -> Modern, feature-rich terminal emulator with excellent cross-platform support[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 
 ---
 ### Terminal File Explorers
@@ -35,7 +35,7 @@ List of Linux Tools I put on almost every Linux / Debian host
 ---
 
 ### LS-like Directory Viewers 
-- [**eza**](https://github.com/eza-community/eza) -> Modern replacement for ls with more features, colors and Git integration (successor to exa)[8]
+- [**eza**](https://github.com/eza-community/eza) -> Modern replacement for ls with more features, colors and Git integration (successor to exa)[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [🌟 **lsd**](https://github.com/lsd-rs/lsd) -> Another ls clone, cross-platform (works on Linux, Mac Win) can also show directory sizes (Peltoche/lsd GitHub) - _personal favorite_
 
 ----
@@ -44,18 +44,18 @@ List of Linux Tools I put on almost every Linux / Debian host
 - [**micro**](https://github.com/zyedidia/micro) -> For those new to Linux, or aren't into _vi_ or _vim_ (/zyedidia/micro on Github)
 - [**ne**](https://ne.di.unimi.it) -> Terminal editor (like nano / code highlighting, "esc" or F1 for menus)
 - [🌟 **vim**](https://github.com/vim/vim) -> VI editor with tons of extras - _personal favorite_
-- [**neovim**](https://neovim.io) -> Text editor that can be configured to mirror VS Code, with a lot of plugins and extensibility[8]
+- [**neovim**](https://neovim.io) -> Text editor that can be configured to mirror VS Code, with a lot of plugins and extensibility[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**vimrc**](https://github.com/amix/vimrc) -> config script for vim (from Github amix/vimrc) -> [⭐ _Try out **vim_awesome** based on this_](https://github.com/ArthurChiao/vim_awesome)
-- [**bat**](https://github.com/sharkdp/bat) -> "cat" clone with syntax highlighting, git integration and other features[8]
-- [**sublime text**](https://www.sublimetext.com) -> Sophisticated text editor for code, markup and prose with slick UI and amazing performance[3]
+- [**bat**](https://github.com/sharkdp/bat) -> "cat" clone with syntax highlighting, git integration and other features[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
+- [**sublime text**](https://www.sublimetext.com) -> Sophisticated text editor for code, markup and prose with slick UI and amazing performance[3](https://www.g2.com/products/acme-text-editor/competitors/alternatives)
 
 ---
 ### Process Explorers 
 - [**glances**](https://nicolargo.github.io/glances/) -> Lots of system info in one "glance", cross-platform (available for Windows) --_installs python_
-- [🌟 **htop**](https://htop.dev) -> Supercharged _top_ clone — _personal favorite_[4]
-- [**btop**](https://github.com/aristocratos/btop) -> TUI CLI graphics, fast, less dependencies than _Glances_[8]
+- [🌟 **htop**](https://htop.dev) -> Supercharged _top_ clone — _personal favorite_[4](https://alternativeto.net/software/process-explorer/)
+- [**btop**](https://github.com/aristocratos/btop) -> TUI CLI graphics, fast, less dependencies than _Glances_[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**bottom**](https://github.com/ClementTsang/bottom) -> A _**btop**_ inspired process monitor, _cross platform_
-- [**system informer**](https://www.systeminformer.com/) -> Official successor to Process Hacker - a powerful, multi-purpose tool to monitor system resources and detect malware[4]
+- [**system informer**](https://www.systeminformer.com/) -> Official successor to Process Hacker - a powerful, multi-purpose tool to monitor system resources and detect malware[4](https://alternativeto.net/software/process-explorer/)
 
 ---
 ### Network-Related Apps
@@ -67,25 +67,25 @@ List of Linux Tools I put on almost every Linux / Debian host
 - [**mtr**](https://www.bitwizard.nl/mtr/) -> Traceroute and ping in one, great for network troubleshooting
 - [**dog**](https://github.com/ogham/dog) -> ``` Dig ```
 - [**neoss**](https://github.com/PabloLec/neoss) -- ```ss```
-- [**zabbix**](https://www.zabbix.com) -> Free monitoring system for networks, servers, and applications that can monitor on-premises resources and cloud services[5]
+- [**zabbix**](https://www.zabbix.com) -> Free monitoring system for networks, servers, and applications that can monitor on-premises resources and cloud services[5](https://www.websentra.com/linux-network-monitor-software-and-tools/)
 ---
 ### Misc CLI Terminal Apps
 
 - [**chkservice**](https://github.com/linuxenko/chkservice) -> TUI Linux _**systemd**_ service review from the terminal (_linuxenko/chkservice_ on Github)
 - [**ncdu**](https://dev.yorhel.nl/ncdu) -> Terminal disk and folder space viewer
-- [**dust**](https://github.com/bootandy/dust) -> More intuitive version of du with bar chart visualization[8]
+- [**dust**](https://github.com/bootandy/dust) -> More intuitive version of du with bar chart visualization[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**duf**](https://github.com/muesli/duf) -> Disk utility TUI with pretty graphs (a better ```df```)
 - [**lynis**](https://cisofy.com/lynis/) -> Linux security auditing by _**CISOFY**_
 - [**apt-show-versions**](https://packages.ubuntu.com/source/focal/apt-show-versions) -> shows package versions / if needing upgrade ("$ apt-show-versions -u")
-- [**nala**](https://gitlab.com/volian/nala) -> Frontend for apt with a more user-friendly interface and colored output[8]
+- [**nala**](https://gitlab.com/volian/nala) -> Frontend for apt with a more user-friendly interface and colored output[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**fd**](https://github.com/sharkdp/fd) -> Linux find clone with saner default options (PC, MAC, Linux, Debian, etc) (sharkdp/fd on Github)
 - [**fish**](https://fishshell.com) -> "friendly interactive shell" beats the pants off of bash, ([Fishshell.com](https://fishshell.com))
-- [**starship**](https://starship.rs) -> Customizable cross-shell prompt with extensive customization options[8]
-- [**zoxide**](https://github.com/ajeetdsouza/zoxide) -> Smarter cd command that learns your habits and helps you navigate faster[8]
+- [**starship**](https://starship.rs) -> Customizable cross-shell prompt with extensive customization options[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
+- [**zoxide**](https://github.com/ajeetdsouza/zoxide) -> Smarter cd command that learns your habits and helps you navigate faster[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**tig**](https://github.com/jonas/tig) -> TUI client for git (jonas/tig on Github)
 - [**miller**](https://github.com/johnkerl/miller) -> Does about everything awk and sed does for json/csv/etc files (johnkerl/miller on Github) 
 - [**most**](https://www.jedsoft.org/most/) -> Linux pager, better than "less" or "more"
-- [**tldr**](https://tldr.sh) -> Simplified man pages that just tell you what you need to know with practical examples[8]
+- [**tldr**](https://tldr.sh) -> Simplified man pages that just tell you what you need to know with practical examples[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**lazydocker**](https://github.com/jesseduffield/lazydocker) -> TUI terminal software for Docker containers (jesseduffield/lazydocker on Github)
 - [**json-tui**](https://github.com/ArthurSonzogni/json-tui) -> Easy way to review json files, has a cool table view (ArthurSonzogni/json-tui Github)
 - [**jc**](https://github.com/kellyjonbrazil/jc) -> Shows common Linux command output in json format (kellyjonbrazil/jc on Github)
@@ -93,11 +93,11 @@ List of Linux Tools I put on almost every Linux / Debian host
 - [**eg**](https://github.com/srsudar/eg) -> [TLDR.sh](https://tldr.sh/) like tool that helps with Linux commands (srsudar/eg on Github)
 - [**procs**](https://github.com/dalance/procs) -> ps replacement
 - [**sd**](https://github.com/chmln/sd) -> sed replacement
-- [**ripgrep**](https://github.com/BurntSushi/ripgrep) -> Extremely fast text search tool that respects gitignore rules[8]
+- [**ripgrep**](https://github.com/BurntSushi/ripgrep) -> Extremely fast text search tool that respects gitignore rules[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 - [**ripgrep-all**](https://github.com/phiresky/ripgrep-all) -> A grep tool with improvements on speed and document formats
 - [**fzf**](https://github.com/junegunn/fzf) -> A command-line fuzzy finder that enhances search and navigation in the terminal. Ideal for quickly finding files, command history, git, and more (junegunn/fzf on GitHub)
-- [**fastfetch**](https://github.com/fastfetch-cli/fastfetch) -> Faster, more feature-rich neofetch alternative for system information display[8]
-- [**pandoc**](https://pandoc.org) -> Universal document converter that can convert between various markup formats[8]
+- [**fastfetch**](https://github.com/fastfetch-cli/fastfetch) -> Faster, more feature-rich neofetch alternative for system information display[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
+- [**pandoc**](https://pandoc.org) -> Universal document converter that can convert between various markup formats[8](https://www.reddit.com/r/selfhosted/comments/1fg3cou/linux_cli_tool_upgradesalternatives/)
 ---
 ## Updates
 * 09/06/25 - README formatting and links improvements; improved ripgrep-all description


### PR DESCRIPTION
Convert numeric citations in `README.md` to clickable links to their respective sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fc48bf4-a9f6-498c-94f9-5df23fbff757">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fc48bf4-a9f6-498c-94f9-5df23fbff757">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

